### PR TITLE
bugfix: Active_Transactions is not counter value

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 REPO = mackerel-plugin-proxysql
 BIN = $(REPO)
-VERSION = 0.0.1
+VERSION = 0.0.2
 
 all: clean test build
 

--- a/mpproxysql/mpproxysql.go
+++ b/mpproxysql/mpproxysql.go
@@ -53,7 +53,7 @@ func (p ProxySQLPlugin) defaultGraphdef() map[string]mp.Graphs {
 			Label: labelPrefix + " Transactions",
 			Unit:  "float",
 			Metrics: []mp.Metrics{
-				{Name: "Active_Transactions", Label: "Active", Diff: true, Stacked: false},
+				{Name: "Active_Transactions", Label: "Active", Diff: false, Stacked: false},
 			},
 		},
 		"connections": {


### PR DESCRIPTION
This bug makes mackerel-agent to produce following error messages.

```
OutputValues:  Counter seems to be reset.\n"
```